### PR TITLE
chore: Rename project repo name to besselstudio

### DIFF
--- a/packages/bessel-uikit/package.json
+++ b/packages/bessel-uikit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@besselstudio-libs/uikit",
+  "name": "@besselstudio/uikit",
   "version": "0.21.0",
   "description": "Set of UI components for pancake projects",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Rename package.json project name from `besselstudio-lib` to `besselstudio`
